### PR TITLE
fix $table_prefix globals overwrite

### DIFF
--- a/src/Blogwerk/Converter.php
+++ b/src/Blogwerk/Converter.php
@@ -182,6 +182,7 @@ class Converter
     
     // Load WordPress
     Output::output('Load WordPress...', 'info');
+    global $table_prefix; // this is needed: we are not in global scope, wp assumes that we are for this variable (see wp-settings.php:82)
     include_once($path . '/wp-load.php');
     
     // Verify the installation


### PR DESCRIPTION
`wp-settings.php:82` assumes the `$table_prefix` variable is in the global
scope and does not declare it `global`.
If you set the `$table_prefix` in i.e. `wp-config.php` it will be
overwritten to null at this point. the easy fix is to declare
`$table_prefix` global before including the `wp-load.php`.
